### PR TITLE
Removed the part of the code that was forcing you to use /svn/ as repository root

### DIFF
--- a/app/controllers/ProjectController.php
+++ b/app/controllers/ProjectController.php
@@ -217,7 +217,7 @@ class ProjectController extends USVN_Controller
 		$project_name = str_replace(USVN_URL_SEP, '/',$this->_project->name);
     	$svn_file_path = $this->getRequest()->getParam('file');
     	$this->view->path = $svn_file_path;
-    	$local_file_path = USVN_SVNUtils::getRepositoryPath($config->subversion->path."/svn/".$project_name."/".$svn_file_path);
+    	$local_file_path = USVN_SVNUtils::getRepositoryPath($config->subversion->path.$project_name."/".$svn_file_path);
     	$file_ext = pathinfo($svn_file_path, PATHINFO_EXTENSION);
 		$revision = $this->getRequest()->getParam('rev');
 		$file_rev = '';
@@ -391,7 +391,7 @@ class ProjectController extends USVN_Controller
 		$this->view->project = $this->_project;
 		$config = new USVN_Config_Ini(USVN_CONFIG_FILE, USVN_CONFIG_SECTION);
 		$project_name = str_replace(USVN_URL_SEP, '/',$this->_project->name);
-		$local_project_path = USVN_SVNUtils::getRepositoryPath($config->subversion->path."/svn/".$project_name."/");
+		$local_project_path = USVN_SVNUtils::getRepositoryPath($config->subversion->path.$project_name."/");
 		$commit = $this->getRequest()->getParam('commit');
 		$base = $commit - 1;
 		$cmd = USVN_SVNUtils::svnCommand("log --non-interactive --revision {$commit} $local_project_path");

--- a/app/install/install.class.php
+++ b/app/install/install.class.php
@@ -247,7 +247,7 @@ class Install
 			$url .= '/';
 		$path = str_replace(DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $path);
 		$config = Install::_loadConfig($config_file);
-		if (file_exists($path) && is_writable($path) && (file_exists($path . DIRECTORY_SEPARATOR . 'svn') || mkdir($path . DIRECTORY_SEPARATOR . 'svn')))
+		if (file_exists($path) && is_writable($path) && (file_exists($path . DIRECTORY_SEPARATOR ) || mkdir($path . DIRECTORY_SEPARATOR )))
 		{
 			$config->subversion = array(
 				'path' => $path,

--- a/library/USVN/Project.php
+++ b/library/USVN/Project.php
@@ -30,7 +30,6 @@ class USVN_Project
 		$config = Zend_Registry::get('config');
 		$path = $config->subversion->path
 		. DIRECTORY_SEPARATOR
-		. 'svn'
 		. DIRECTORY_SEPARATOR
 		. $project_name;
 		if (!USVN_SVNUtils::isSVNRepository($path, true)) {
@@ -192,7 +191,6 @@ class USVN_Project
 
 		USVN_DirectoryUtils::removeDirectory(Zend_Registry::get('config')->subversion->path
 		. DIRECTORY_SEPARATOR
-		. 'svn'
 		. DIRECTORY_SEPARATOR
 		. $project_name);
 

--- a/library/USVN/SVN.php
+++ b/library/USVN/SVN.php
@@ -32,7 +32,7 @@ class USVN_SVN
             throw new USVN_Exception(T_("Invalid project name %s."), $project);
         }
 		$this->_project = $project;
-		$this->_repository = Zend_Registry::get('config')->subversion->path . '/svn/' . $this->_project;
+		$this->_repository = Zend_Registry::get('config')->subversion->path . $this->_project;
 	}
 
 	/**


### PR DESCRIPTION
I Removed part of the code that adds ./svn/ to the subversion.path from the config, which forced you to always use the folder ./svn/ as your repository root.

I worked with it for a few days now and it all seems to work. I don't know if you need this change, but I found it a lot better to use than a hardcoded /svn/ as repository root. Now I can use something like /home/svn/repos/ (and not /home/svn/repos/svn/ for example)
as root.
I have not touched the testfiles, but it seems it is hardcoded there too. 
