### PR TITLE
Use long instead of short open PHP tag.

### DIFF
--- a/src/app/layouts/default.phtml
+++ b/src/app/layouts/default.phtml
@@ -30,7 +30,7 @@
 					<div id="main-menu">
 						<ul>
 							<?php if ($this->isLogged): ?>
-							<?
+							<?php
 								$array = array();
 								$array['index'] = T_('Home');
 								$array['profile'] = T_('Profile');


### PR DESCRIPTION
This allows one to run USVN on (modern) servers without support for
short open tags and fixes the following error message:
error, unexpected 'endforeach' (T_ENDFOREACH) in
.../src/app/layouts/default.phtml on line 42