### PR TITLE
replacing split by explode

### DIFF
--- a/src/app/controllers/BrowserajaxController.php
+++ b/src/app/controllers/BrowserajaxController.php
@@ -215,8 +215,8 @@ class BrowserajaxController extends USVN_Controller
 
 			$msg = "Ok";
 
-			$tabgroup = split(",", $_GET['group']);
-			$tabrights = split(",", $_GET['rights']);
+			$tabgroup = explode(",", $_GET['group']);
+			$tabrights = explode(",", $_GET['rights']);
 			$j = 0;
 			foreach ($tabgroup as $group)
 			{


### PR DESCRIPTION
Hello 
I replace split (deprecated in php 5.3.0, removed in php 7.0.0) by explode to make usvn run on recent php versions.
