### PR TITLE
Solve some problems about binary file, locale and mysql importing.

### DIFF
--- a/src/app/bootstrap.php
+++ b/src/app/bootstrap.php
@@ -78,6 +78,7 @@ date_default_timezone_set($config->timezone);
 USVN_ConsoleUtils::setLocale($config->system->locale);
 USVN_Translation::initTranslation($config->translation->locale, USVN_LOCALE_DIR);
 USVN_Template::initTemplate($config->template->name, USVN_MEDIAS_DIR);
+setlocale(LC_ALL, $config->system->locale);
 
 /* Zend Configuration */
 Zend_Registry::set('config', $config);

--- a/src/app/controllers/ProjectController.php
+++ b/src/app/controllers/ProjectController.php
@@ -369,6 +369,7 @@ class ProjectController extends USVN_Controller
 			$geshi->set_source($source);
 	    	$geshi->set_header_type(GESHI_HEADER_DIV);
 			$this->view->highlighted_source = $geshi->parse_code();
+			$this->view->source = $source;
 			if ($this->view->diff_view)
 			{
 				if (preg_match('#^<div ([^>]*)><ol>(.*)</ol></div>(\s*)$#s', $this->view->highlighted_source, $tmp))

--- a/src/app/install/sql/mysql.sql
+++ b/src/app/install/sql/mysql.sql
@@ -63,7 +63,7 @@ create index usvn_groups_to_projects2_fk on usvn_groups_to_projects
 create table usvn_projects
 (
    projects_id                    int                            not null auto_increment,
-   projects_name                  varchar(255)                   not null,
+   projects_name                  varchar(127)                   not null,
    projects_start_date            datetime                       not null,
    projects_description           varchar(1000),
    CONSTRAINT PROJECTS_NAME_UNQ UNIQUE (projects_name),
@@ -74,7 +74,7 @@ ENGINE=InnoDB;
 create table usvn_users
 (
    users_id                       int                            not null auto_increment,
-   users_login                    varchar(255)                   not null,
+   users_login                    varchar(127)                   not null,
    users_password                 varchar(64)                    not null,
    users_lastname                 varchar(100),
    users_firstname                varchar(100),

--- a/src/app/views/scripts/project/show.phtml
+++ b/src/app/views/scripts/project/show.phtml
@@ -59,7 +59,15 @@
   </p>
 </div>
 <?php
-  if (!$this->diff_view) {
+  $finfo = new finfo(FILEINFO_MIME);
+  $mime = $finfo->buffer($this->source);
+  $mime = substr($mime, 0, strpos($mime, "/"));
+  if ($mime == "image") {
+    $file = USVN_SVNUtils::getSubversionUrl($this->project->name, "/".$this->path)."?p=$this->revision";
+    echo "<img src=$file width=100% height=auto/>";
+  } elseif ($mime != "text") {
+    echo T_('Unsupported binary file type.');
+  } elseif (!$this->diff_view) {
     echo $this->highlighted_source;
   }
   else {


### PR DESCRIPTION
1. Solve the problem that the binary file is shown by the messy text code.
    The image binary should show the image.
    The other binary shouldn't show the content.

2. Set the locale by system.locale in the config file.
    Otherwise error will occured by showing the content of file that the name has non-ASCII characters.
    It is caused by calling the escapeshellarg function.

3. Solve the key length error reported by mysql when import the sql.