### PR TITLE
Add X-Forwarded-Proto variable check on protocol check

### DIFF
--- a/src/app/install/index.php
+++ b/src/app/install/index.php
@@ -108,7 +108,7 @@ function installationOperation(&$step)
 
 		case 2:
 			$errors = Install::check();
-			Install::installUrl(USVN_CONFIG_FILE, USVN_HTACCESS_FILE, $_SERVER['REQUEST_URI'], $_SERVER['HTTP_HOST'], isset($_SERVER['HTTPS']));
+			Install::installUrl(USVN_CONFIG_FILE, USVN_HTACCESS_FILE, $_SERVER['REQUEST_URI'], $_SERVER['HTTP_HOST'], isset($_SERVER['HTTPS']) || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'));
 			break;
 
 		case 3:

--- a/src/app/install/views/step4.html
+++ b/src/app/install/views/step4.html
@@ -69,10 +69,10 @@
 			</td>
 			<td>
 				<input type="text" size="67" name="urlSubversion" value="<?php
-					if (isset($_SERVER['HTTPS']))
+					if (isset($_SERVER['HTTPS']) || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https'))
 					{
 						$method = 'https://';
-						$port = ($_SERVER['SERVER_PORT'] != 443) ? (':' . $_SERVER['SERVER_PORT']) : '';
+						$port = !(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') && ($_SERVER['SERVER_PORT'] != 443) ? (':' . $_SERVER['SERVER_PORT']) : '';
 					}
 					else
 					{


### PR DESCRIPTION
I'm using usvn with reverse proxy that supports https.
But web installer does not check X-Forwareded-Proto on building url.
So I fixed there codes.