### PR TITLE
Fix PHP 7 warnings.

### DIFF
--- a/src/app/controllers/GroupadminController.php
+++ b/src/app/controllers/GroupadminController.php
@@ -64,7 +64,7 @@ class GroupadminController extends AdminadminController
 		}
 		try {
 			$group->save();
-			foreach ($_POST['users'] as $user) {
+			foreach ((array)$_POST['users'] as $user) {
 				$group->addUser($user);
 			}
 			$this->_redirect("/admin/group/");

--- a/src/library/Zend/Ldap/Converter.php
+++ b/src/library/Zend/Ldap/Converter.php
@@ -69,7 +69,13 @@ class Zend_Ldap_Converter
      */
     public static function hex32ToAsc($string)
     {
-        $string = preg_replace("/\\\([0-9A-Fa-f]{2})/e", "''.chr(hexdec('\\1')).''", $string);
+        $string = preg_replace_callback(
+            "/\\\[0-9A-Fa-f]{2}/",
+            function ($matches) {
+                return chr(hexdec($matches[0]));
+            },
+            $string
+        );
         return $string;
     }
 


### PR DESCRIPTION
Fixed PHP 7 warning.  

> [php7:warn] [pid 208] [client localhost:62993] PHP Warning:  Invalid argument supplied for foreach() in /var/www/usvn/app/controllers/GroupadminController.php on line 67, referer: http://localhost/usvn/admin/group/new

and

> [php7:warn] [pid 208] [client localhost:62993] PHP Warning:  preg_replace(): The /e modifier is no longer supported, use preg_replace_callback instead in /var/www/usvn/library/Zend/Ldap/Converter.php on line 72, referer: http://localhost/usvn/login/