### PR TITLE
Fix error on assigning groups to users

### DIFF
--- a/src/library/Zend/Db/Table/Abstract.php
+++ b/src/library/Zend/Db/Table/Abstract.php
@@ -1233,13 +1233,13 @@ abstract class Zend_Db_Table_Abstract
         $whereList = array();
         $numberTerms = 0;
         foreach ($args as $keyPosition => $keyValues) {
-            $keyValuesCount = count($keyValues);
             // Coerce the values to an array.
             // Don't simply typecast to array, because the values
             // might be Zend_Db_Expr objects.
             if (!is_array($keyValues)) {
                 $keyValues = array($keyValues);
             }
+            $keyValuesCount = count($keyValues);
             if ($numberTerms == 0) {
                 $numberTerms = $keyValuesCount;
             } else if ($keyValuesCount != $numberTerms) {


### PR DESCRIPTION
Since PHP 8.0 the count() function throws a TypeError when a non-countable type is passed to it. This resulted in the following error when trying to change the group assignment of a user:
```
PHP Fatal error:  Uncaught TypeError: count():
  Argument #1 ($value) must be of type Countable|array, string given
  in usvn/library/Zend/Db/Table/Abstract.php:1236

Stack trace:
#0 usvn/library/USVN/Db/Table/Row/User.php(31): Zend_Db_Table_Abstract->find()
#1 usvn/library/USVN/User.php(118): USVN_Db_Table_Row_User->addGroup()
#2 usvn/app/controllers/UseradminController.php(125): USVN_User->save()
...
``` 

The Zend code already coerces the passed argument to an array, unfortunately only after the call to count(). To fix this we just move it behind it.

Fixes #80