### PR TITLE
Feature/ldap enhancements

### DIFF
--- a/src/app/controllers/ProfileController.php
+++ b/src/app/controllers/ProfileController.php
@@ -73,18 +73,25 @@ class ProfileController extends USVN_Controller
 	public function saveAction()
 	{
 		$user = $this->getUser();
-		try {
-			$data = $this->getUserData($_POST);
-			if (empty($data)) {
-				$this->_redirect("/profile/");
+		$config = new USVN_Config_Ini(USVN_CONFIG_FILE, USVN_CONFIG_SECTION);
+		if($config->authAdapterMethod!=='ldap' || $config->alwaysUseDatabaseForLogin===$user->users_login) {
+			try {
+				$data = $this->getUserData($_POST);
+				if (empty($data)) {
+					$this->_redirect("/profile/");
+				}
+				$user->setFromArray($data);
+				$user->save();
+				$this->_redirect("/");
 			}
-			$user->setFromArray($data);
-			$user->save();
-			$this->_redirect("/");
-		}
-		catch (Exception $e) {
+			catch (Exception $e) {
+				$this->view->user = $user;
+				$this->view->message = $e->getMessage();
+				$this->render('index');
+			}
+		} else {
 			$this->view->user = $user;
-			$this->view->message = $e->getMessage();
+			$this->view->message = "LDAP user cannot modify profile informations";
 			$this->render('index');
 		}
 	}

--- a/src/app/controllers/ProfileController.php
+++ b/src/app/controllers/ProfileController.php
@@ -63,6 +63,7 @@ class ProfileController extends USVN_Controller
 
 	public function indexAction()
 	{
+		$this->view->config = new USVN_Config_Ini(USVN_CONFIG_FILE, USVN_CONFIG_SECTION);
 		$this->view->user = $this->getUser();
 		if ($this->view->user === null) {
 			$this->_redirect("/admin/user/");

--- a/src/app/views/scripts/configadmin/index.phtml
+++ b/src/app/views/scripts/configadmin/index.phtml
@@ -307,6 +307,25 @@
 			</td>
 		</tr>
 		<tr>
+			<td><label><?php echo T_("Try split username"); ?>:</label></td>
+			<td>
+				<select name="ldap[tryUsernameSplit]">
+					<?php
+						if (!isset($this->config->ldap->options->tryUsernameSplit) || ($this->config->ldap->options->tryUsernameSplit))
+						{
+							echo '<option value="1" selected>' . T_("Yes"). '</option>';
+							echo '<option value="0">' . T_("No"). '</option>';
+						}
+						else
+						{
+							echo '<option value="1">' . T_("Yes"). '</option>';
+							echo '<option value="0" selected>' . T_("No"). '</option>';
+						}
+					?>
+				</select>
+			</td>
+		</tr>
+		<tr>
 			<td><label><?php echo T_("Allow empty password"); ?>:</label></td>
 			<td>
 				<select name="ldap[allowEmptyPassword]">

--- a/src/app/views/scripts/profile/index.phtml
+++ b/src/app/views/scripts/profile/index.phtml
@@ -32,27 +32,33 @@ function checkForm() {
 	<h1><?php echo T_("My account"); ?></h1>
 </div>
 <div id="profile">
-	<form id="user" class="usvn_form" method="post" action="<?php echo $this->url(array("action" => "save")); ?>">
-		<label for="users_password"><?php echo T_("Actual password"); ?><span class="usvn_require">*</span><br />
-			<?php echo $this->formPassword('users_password',  null); ?>
-		</label>
-		<br />
-		<label><?php echo T_("New password"); ?><br />
-			<?php echo $this->formPassword('users_new_password',  null); ?>
-		</label>
-			<?php echo $this->formPassword('users_new_password_copy',  null); ?>
-		<br />
-		<label><?php echo T_("Lastname"); ?><br />
-			<?php echo $this->formText('users_lastname', $this->user->lastname, array('maxlength' => 100)); ?></label>
-		<br />
-		<label><?php echo T_("Firstname"); ?><br />
-			<?php echo $this->formText('users_firstname', $this->user->firstname, array('maxlength' => 100)); ?>
-		</label>
-		<br />
-		<label><?php echo T_("Email"); ?><br />
-			<?php echo $this->formText('users_email', $this->user->email, array('maxlength' => 150)); ?>
-		</label>
-		<br />
-		<?php echo $this->formSubmit('submit', T_("Submit"), array("onclick" => 'return checkForm();')); ?>
-	</form>
+	<?php if($this->config->authAdapterMethod!=='ldap' || $this->config->alwaysUseDatabaseForLogin===$this->user->users_login) { ?>
+		<form id="user" class="usvn_form" method="post" action="<?php echo $this->url(array("action" => "save")); ?>">
+			<label for="users_password"><?php echo T_("Actual password"); ?><span class="usvn_require">*</span><br />
+				<?php echo $this->formPassword('users_password',  null); ?>
+			</label>
+			<br />
+			<label><?php echo T_("New password"); ?><br />
+				<?php echo $this->formPassword('users_new_password',  null); ?>
+			</label>
+				<?php echo $this->formPassword('users_new_password_copy',  null); ?>
+			<br />
+			<label><?php echo T_("Lastname"); ?><br />
+				<?php echo $this->formText('users_lastname', $this->user->lastname, array('maxlength' => 100)); ?></label>
+			<br />
+			<label><?php echo T_("Firstname"); ?><br />
+				<?php echo $this->formText('users_firstname', $this->user->firstname, array('maxlength' => 100)); ?>
+			</label>
+			<br />
+			<label><?php echo T_("Email"); ?><br />
+				<?php echo $this->formText('users_email', $this->user->email, array('maxlength' => 150)); ?>
+			</label>
+			<br />
+			<?php echo $this->formSubmit('submit', T_("Submit"), array("onclick" => 'return checkForm();')); ?>
+		</form>
+	<?php } else { ?>
+		<label><?= T_("Lastname") ?>:</label> <?= $this->user->lastname ?><br />
+		<label><?= T_("Firstname") ?>:</label> <?= $this->user->firstname ?><br />
+		<label><?= T_("Email") ?>:</label> <?= $this->user->email ?><br />
+	<?php } ?>
 </div>

--- a/src/library/USVN/Config.php
+++ b/src/library/USVN/Config.php
@@ -121,21 +121,21 @@ class USVN_Config
 		}
 		$config->ldap->createGroupForUserInDB = filter_var($ldap_options['createGroupForUserInDB'], FILTER_SANITIZE_NUMBER_INT);
 		$config->ldap->createUserInDBOnLogin = filter_var($ldap_options['createUserInDBOnLogin'], FILTER_SANITIZE_NUMBER_INT);
-		if (strlen($ldap_options['host'])) $config->ldap->options->host = filter_var($ldap_options['host'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['port'])) $config->ldap->options->port = filter_var($ldap_options['port'], FILTER_SANITIZE_NUMBER_INT);
-		if (strlen($ldap_options['username'])) $config->ldap->options->username = filter_var($ldap_options['username'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['password'])) $config->ldap->options->password = filter_var($ldap_options['password'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['useStartTls'])) $config->ldap->options->useStartTls = filter_var($ldap_options['useStartTls'], FILTER_SANITIZE_NUMBER_INT);
-		if (strlen($ldap_options['useSsl'])) $config->ldap->options->useSsl = filter_var($ldap_options['useSsl'], FILTER_SANITIZE_NUMBER_INT);
-		if (strlen($ldap_options['bindDnFormat'])) $config->ldap->options->bindDnFormat = filter_var($ldap_options['bindDnFormat'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['bindRequiresDn'])) $config->ldap->options->bindRequiresDn = filter_var($ldap_options['bindRequiresDn'], FILTER_SANITIZE_NUMBER_INT);
-		if (strlen($ldap_options['baseDn'])) $config->ldap->options->baseDn = filter_var($ldap_options['baseDn'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['accountCanonicalForm'])) $config->ldap->options->accountCanonicalForm = filter_var($ldap_options['accountCanonicalForm'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['accountDomainName'])) $config->ldap->options->accountDomainName = filter_var($ldap_options['accountDomainName'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['accountDomainNameShort'])) $config->ldap->options->accountDomainNameShort = filter_var($ldap_options['accountDomainNameShort'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['accountFilterFormat'])) $config->ldap->options->accountFilterFormat = filter_var($ldap_options['accountFilterFormat'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		if (strlen($ldap_options['allowEmptyPassword'])) $config->ldap->options->allowEmptyPassword = filter_var($ldap_options['allowEmptyPassword'], FILTER_SANITIZE_NUMBER_INT);
-		if (strlen($ldap_options['optReferrals'])) $config->ldap->options->optReferrals = filter_var($ldap_options['optReferrals'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->host = filter_var($ldap_options['host'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->port = filter_var($ldap_options['port'], FILTER_SANITIZE_NUMBER_INT);
+		$config->ldap->options->username = filter_var($ldap_options['username'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->password = filter_var($ldap_options['password'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->useStartTls = filter_var($ldap_options['useStartTls'], FILTER_SANITIZE_NUMBER_INT);
+		$config->ldap->options->useSsl = filter_var($ldap_options['useSsl'], FILTER_SANITIZE_NUMBER_INT);
+		$config->ldap->options->bindDnFormat = filter_var($ldap_options['bindDnFormat'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->bindRequiresDn = filter_var($ldap_options['bindRequiresDn'], FILTER_SANITIZE_NUMBER_INT);
+		$config->ldap->options->baseDn = filter_var($ldap_options['baseDn'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->accountCanonicalForm = filter_var($ldap_options['accountCanonicalForm'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->accountDomainName = filter_var($ldap_options['accountDomainName'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->accountDomainNameShort = filter_var($ldap_options['accountDomainNameShort'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->accountFilterFormat = filter_var($ldap_options['accountFilterFormat'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->allowEmptyPassword = filter_var($ldap_options['allowEmptyPassword'], FILTER_SANITIZE_NUMBER_INT);
+		$config->ldap->options->optReferrals = filter_var($ldap_options['optReferrals'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		$config->save();
 	}
 

--- a/src/library/USVN/Config.php
+++ b/src/library/USVN/Config.php
@@ -133,7 +133,7 @@ class USVN_Config
 		$config->ldap->options->accountCanonicalForm = filter_var($ldap_options['accountCanonicalForm'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		$config->ldap->options->accountDomainName = filter_var($ldap_options['accountDomainName'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		$config->ldap->options->accountDomainNameShort = filter_var($ldap_options['accountDomainNameShort'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-		$config->ldap->options->accountFilterFormat = filter_var($ldap_options['accountFilterFormat'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+		$config->ldap->options->accountFilterFormat = filter_var($ldap_options['accountFilterFormat'], FILTER_SANITIZE_URL);
 		$config->ldap->options->allowEmptyPassword = filter_var($ldap_options['allowEmptyPassword'], FILTER_SANITIZE_NUMBER_INT);
 		$config->ldap->options->optReferrals = filter_var($ldap_options['optReferrals'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		$config->save();

--- a/src/library/USVN/Config.php
+++ b/src/library/USVN/Config.php
@@ -134,6 +134,7 @@ class USVN_Config
 		$config->ldap->options->accountDomainName = filter_var($ldap_options['accountDomainName'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		$config->ldap->options->accountDomainNameShort = filter_var($ldap_options['accountDomainNameShort'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		$config->ldap->options->accountFilterFormat = filter_var($ldap_options['accountFilterFormat'], FILTER_SANITIZE_URL);
+		$config->ldap->options->tryUsernameSplit = filter_var($ldap_options['tryUsernameSplit'], FILTER_SANITIZE_NUMBER_INT);
 		$config->ldap->options->allowEmptyPassword = filter_var($ldap_options['allowEmptyPassword'], FILTER_SANITIZE_NUMBER_INT);
 		$config->ldap->options->optReferrals = filter_var($ldap_options['optReferrals'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
 		$config->save();

--- a/src/library/USVN/Config/Ini.php
+++ b/src/library/USVN/Config/Ini.php
@@ -46,6 +46,8 @@
 		try
 		{
 			parent::__construct($filename, $section, true);
+			// Load some mandatory defaults
+			if (!isset($ithis->url)) { $this->url = array(); $this->url->base = ''; }
 		}
 		catch (Exception $e)
 		{
@@ -60,7 +62,8 @@
 			if (is_object($value))
 				$this->dumpLevel($handle, "$prefix$key.", $value);
 			else
-				fwrite($handle, "$prefix$key = \"$value\"\n");
+				if ($value!=='')
+					fwrite($handle, "$prefix$key = \"$value\"\n");
 		}
 	}
 

--- a/src/library/USVN/Db/Table/Row/User.php
+++ b/src/library/USVN/Db/Table/Row/User.php
@@ -133,7 +133,7 @@ class USVN_Db_Table_Row_User extends USVN_Db_Table_Row
 		if (empty($login) || preg_match('/^\s+$/', $login)) {
 			throw new USVN_Exception(T_('Login empty.'));
 		}
-		if (!preg_match('/^[0-9a-zA-Z_\-\.]+$/', $login)) {
+		if (!preg_match('/^[@0-9a-zA-Z_\-\.]+$/', $login)) {
 			throw new USVN_Exception(T_("Login invalid.  The login can only include alpha-numeric characters and '.', '-' or '_'."));
 		}
 	}


### PR DESCRIPTION
This pull request contains a few relevant improvements for the LDAP authentication method:

- The input form for the LDAP options has two problems. Firstly, once values have been entered, they cannot be removed, and secondly, certain special characters cannot be entered in the “Account filter format” option. These include the ampersand, which may occur in a filter.

- Usernames for LDAP do not have to be in the form of an email address, but they can be. However, USVN does not allow the @ sign in user names.

-  There is another, sometimes important LDAP option called “tryUsernameSplit.” This option cannot be set via the UI.

- A user who is logged in via LDAP should not be able to customize their profile. 

All these points have been corrected.