### PR TITLE
feat: Readability of long project names by inserting title attributes

### DIFF
--- a/src/app/views/scripts/index/index.phtml
+++ b/src/app/views/scripts/index/index.phtml
@@ -11,7 +11,7 @@
 				<div class="grid_img">
 					<?php echo $this->img('box48.png'); ?>
 				</div>
-				<div><?php
+				<div title="<?php echo htmlentities($project->name, ENT_QUOTES) ?>"><?php
 					if (strlen($project->name) > $this->maxlen) {
 						echo substr($project->name, 0, $this->maxlen), '<br />';
 						if (strlen($project->name) > ($this->maxlen * 2 - 3)) {


### PR DESCRIPTION
Very long project names are abbreviated in the main project list. To ensure that you don't lose track of things when dealing with a very long list, you can use this adjustment to display the entire name by hovering over it with the mouse.